### PR TITLE
build:the pipeline should run on all branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
-on:
-  push:
-    branches:
-    - master
+on: push
 jobs:
   release:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Semantic Release will trigger only on `master`