### PR TITLE
Semantic Release Conformance check

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,5 +1,5 @@
-# Always validate all commits, and ignore the PR title
-commitsOnly: true
+# Always validate the PR title AND all the commits
+titleAndCommits: true
 # Require at least one commit to be valid
 # this is only relevant when using commitsOnly: true or titleAndCommits: true,
 # which validate all commits by default

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,7 @@
+# Always validate all commits, and ignore the PR title
+commitsOnly: true
+# Require at least one commit to be valid
+# this is only relevant when using commitsOnly: true or titleAndCommits: true,
+# which validate all commits by default
+anyCommit: true
+# Related docs https://github.com/zeke/semantic-pull-requests#configuration


### PR DESCRIPTION
This Configuration triggers this [Github app](https://github.com/zeke/semantic-pull-requests) to validate that at least one message is conformant to `semantic-release`