### PR TITLE
docs: add documentation for boom without orbiter

### DIFF
--- a/docs/boom/boom.md
+++ b/docs/boom/boom.md
@@ -28,7 +28,7 @@ There has to be a git-repository with an boom.yml in the base. Then a `BOOM` ins
 orbctl -f $HOME/.orb/config takeoff
 ```
 
-If you want to run boom together with orbiter you can follow the documentation in the [readme.md](../../readme.md). If you want to run boom on a existing cluster
+If you want to run boom together with orbiter you can follow the documentation in the [README.md](../../README.md). If you want to run boom on a existing cluster
 
 ## Boom on an existing Cluster
 

--- a/docs/boom/boom.md
+++ b/docs/boom/boom.md
@@ -20,6 +20,48 @@ Upcoming tools:
 
 - Flux
 
+## How to use it
+
+There has to be a git-repository with an boom.yml in the base. Then a `BOOM` instance can be started with
+
+```bash
+orbctl -f $HOME/.orb/config takeoff
+```
+
+If you want to run boom together with orbiter you can follow the documentation in the [readme.md](../../readme.md). If you want to run boom on a existing cluster
+
+## Boom on an existing Cluster
+
+If you just want to use Boom without Orbiter to bootstrap some tools you can follow these steps:
+
+1. Install orbctl locally
+
+```
+curl -s https://api.github.com/repos/caos/orbos/releases/latest | grep "browser_download_url.*orbctl-$(uname)-$(uname -m)" | cut -d '"' -f 4 | sudo wget -i - -O /usr/local/bin/orbctl
+sudo chmod +x /usr/local/bin/orbctl
+sudo chown $(id -u):$(id -g) /usr/local/bin/orbctl
+```
+
+2. Create a git Repository with a [boom.yml](../../examples/boom/boom.yml)
+3. Optional: [configure your boom.yml](yml/v1beta2/Toolset.md)
+4. [Create SSH Key](https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)
+5. Add SSH Key to your repository (usually called deployment or access key depending on your git provider)
+6. Create an orb config (usually in ~/.orb/config)
+
+```yaml
+url: git@[your-git-provider]:[path-to-your-repository].git
+repokey: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  insert the generated private key
+  -----END OPENSSH PRIVATE KEY-----
+masterkey: [create key with `openssl rand -base64 21`]
+```
+
+7. Commit / Push everything
+8. Make sure your `~/.kube/config` contains a kubeconfig with access to your cluster (https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+9. Start boom with `orbctl -f ~/.orb/config takeoff --kubeconfig ~/.kube/config`
+10. Boom should now be provisioning the applications you configured in your `boom.yml`
+
 ## How does it work
 
 The operator works by reading a configuration (crd) located in a GIT Repository.
@@ -64,13 +106,6 @@ spec:
       storageClass: standard
 ```
 
-## How to use it
-
-There has to be a git-repository with an boom.yml in the base. Then a `BOOM` instance can be started with 
-```bash
-orbctl -f $HOME/.orb/config takeoff
-```
-
-## Structure of the used boom.yml 
+## Structure of the used boom.yml
 
 Jump to the [latest](yml/latest/Toolset.md) configuration options or to the older API versions [v1beta2](yml/v1beta2/Toolset.md) or [v1beta1](yml/v1beta1/Toolset.md)

--- a/docs/boom/boom.md
+++ b/docs/boom/boom.md
@@ -32,7 +32,7 @@ If you want to run boom together with orbiter you can follow the documentation i
 
 ## Boom on an existing Cluster
 
-If you just want to use Boom without Orbiter to bootstrap some tools you can follow these steps:
+If you just want to use `BOOM` without `ORBITER` to bootstrap some tools you can follow these steps:
 
 1. Install orbctl locally
 


### PR DESCRIPTION
This PR adds some documentation to `boom.md` on how to use Boom without Orbiter on an existing cluster.