### PR TITLE
fix: avoid errors from k8s implicitly lowercasing node names

### DIFF
--- a/internal/operator/orbiter/kinds/providers/static/desired.go
+++ b/internal/operator/orbiter/kinds/providers/static/desired.go
@@ -1,6 +1,9 @@
 package static
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/caos/orbos/internal/operator/orbiter"
 	secret2 "github.com/caos/orbos/pkg/secret"
 	"github.com/caos/orbos/pkg/tree"
@@ -78,9 +81,24 @@ type Machine struct {
 	ReplacementRequired bool
 }
 
-func (c *Machine) validate() error {
-	if c.ID == "" {
-		return errors.New("No id provided")
+var internetHosts = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+func validateName(name string) error {
+	if len(name) > 63 || !internetHosts.MatchString(name) {
+		return errors.Errorf("name must be compatible with https://tools.ietf.org/html/rfc1123#section-2, but %s is not", name)
 	}
+	return nil
+}
+
+func (c *Machine) validate() error {
+
+	if err := validateName(c.ID); err != nil {
+		return fmt.Errorf("validating id failed: %w", err)
+	}
+
+	if err := validateName(c.Hostname); err != nil {
+		return fmt.Errorf("validating hostname failed: %w", err)
+	}
+
 	return c.IP.Validate()
 }

--- a/internal/operator/orbiter/kinds/providers/static/desired_test.go
+++ b/internal/operator/orbiter/kinds/providers/static/desired_test.go
@@ -1,0 +1,67 @@
+package static
+
+import (
+	"testing"
+
+	"github.com/caos/orbos/internal/operator/orbiter"
+)
+
+func TestMachine_validate(t *testing.T) {
+	type fields struct {
+		ID                  string
+		Hostname            string
+		IP                  orbiter.IPAddress
+		RebootRequired      bool
+		ReplacementRequired bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{{
+		name: "It should succeed when names are RFC 1123 compatible",
+		fields: fields{
+			ID:       "valid-name-1",
+			Hostname: "valid-name-1",
+			IP:       "127.0.0.1",
+		},
+		wantErr: false,
+	}, {
+		name: "It should fail when names have uppercase letters",
+		fields: fields{
+			ID:       "inValidName",
+			Hostname: "inValidName",
+			IP:       "127.0.0.1",
+		},
+		wantErr: true,
+	}, {
+		name: "It should fail when the ID is empty",
+		fields: fields{
+			Hostname: "valid-name-1",
+			IP:       "127.0.0.1",
+		},
+		wantErr: true,
+	}, {
+		name: "It should fail when the ID is too long",
+		fields: fields{
+			ID:       "a-too-long-name-that-possibly-breaks-many-applications-as-it-doesnt-adhere-to-rfc-1123",
+			Hostname: "valid-name-1",
+			IP:       "127.0.0.1",
+		},
+		wantErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Machine{
+				ID:                  tt.fields.ID,
+				Hostname:            tt.fields.Hostname,
+				IP:                  tt.fields.IP,
+				RebootRequired:      tt.fields.RebootRequired,
+				ReplacementRequired: tt.fields.ReplacementRequired,
+			}
+			if err := c.validate(); (err != nil) != tt.wantErr {
+				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/k8s/name.go
+++ b/pkg/kubernetes/k8s/name.go
@@ -1,0 +1,1 @@
+package k8s


### PR DESCRIPTION
 @tribock found that ORBITER can't find the nodes it created when they have CAPITALS in orbiter.yml, as Kubernetes implicitly converts them to lowercases.