### PR TITLE
Fw target

### DIFF
--- a/internal/operator/nodeagent/firewall/centos/target.go
+++ b/internal/operator/nodeagent/firewall/centos/target.go
@@ -11,8 +11,8 @@ func getEnsureTarget(monitor mntr.Monitor, zoneName string) ([]string, error) {
 		return changeTarget, err
 	}
 
-	if target != "ACCEPT" {
-		changeTarget = []string{"--permanent", "--set-target=ACCEPT"}
+	if target != "default" {
+		changeTarget = []string{"--permanent", "--set-target=default"}
 	}
 	return changeTarget, nil
 }

--- a/internal/operator/orbiter/kinds/clusters/kubernetes/plugins.go
+++ b/internal/operator/orbiter/kinds/clusters/kubernetes/plugins.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strings"
 	"text/template"
@@ -44,10 +45,15 @@ func ensureK8sPlugins(
 		return nil
 	}
 
-	applyResources, err := providerK8sSpec.CleanupAndApply(k8sClient)
-	if err != nil {
-		return err
+	var applyResources io.Reader
+
+	if providerK8sSpec.CleanupAndApply != nil {
+		applyResources, err = providerK8sSpec.CleanupAndApply(k8sClient)
+		if err != nil {
+			return err
+		}
 	}
+
 	if applyResources != nil {
 		k8sPluginsMonitor = k8sPluginsMonitor.WithField("cloudcontrollermanager", providerK8sSpec.CloudController.ProviderName)
 	}


### PR DESCRIPTION
According to [this guide](https://www.linuxjournal.com/content/understanding-firewalld-multi-zone-configurations) when zones have target ACCEPT, they accept each packet matching the sources or intefaces. So each packet coming from eth0 was accepted, effectively not restricting external access. The target should be default so that non matching packets get delegated to other zones. Also see https://firewalld.org/documentation/zone/options.html