### PR TITLE
fix: always ensure kubelet and kubectl before kubeadm

### DIFF
--- a/cmd/chore/e2e/.gitignore
+++ b/cmd/chore/e2e/.gitignore
@@ -1,0 +1,1 @@
+./artifacts

--- a/internal/operator/nodeagent/dep/k8s/kubelet/dep.go
+++ b/internal/operator/nodeagent/dep/k8s/kubelet/dep.go
@@ -49,7 +49,7 @@ func (*kubeletDep) Equals(other nodeagent.Installer) bool {
 func (k *kubeletDep) Current() (pkg common.Package, err error) {
 
 	pkg, err = k.common.Current()
-	if err != nil {
+	if err != nil || pkg.Version == "" {
 		return pkg, err
 	}
 

--- a/internal/operator/nodeagent/dep/keepalived/dep.go
+++ b/internal/operator/nodeagent/dep/keepalived/dep.go
@@ -51,7 +51,7 @@ func (*keepaliveDDep) Equals(other nodeagent.Installer) bool {
 func (s *keepaliveDDep) Current() (pkg common.Package, err error) {
 
 	defer func() {
-		if err == nil {
+		if err == nil && pkg.Version != "" {
 			err = selinux.Current(s.os, &pkg)
 		}
 	}()

--- a/scripts/build-debug-bins.sh
+++ b/scripts/build-debug-bins.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-go run -race ./cmd/gen-executables/*.go \
+go run -race ./cmd/chore/gen-executables/*.go \
   --version $(git rev-parse --abbrev-ref HEAD | sed -e "s/heads\///") \
   --commit $(git rev-parse HEAD) \
   --githubclientid "${ORBOS_GITHUBOAUTHCLIENTID}" \

--- a/scripts/debug-na.sh
+++ b/scripts/debug-na.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+DEVELOPER_IP="$1"
+
+shift
+
 set -ex
 
 stop-na.sh
@@ -16,7 +20,8 @@ else
     ./Code/bin/dlv version || exit 1
 fi
 
-sudo firewall-cmd --permanent --zone external --add-port 5001/tcp || exit 1
+sudo firewall-cmd --permanent --zone work --add-source ${DEVELOPER_IP} || exit 1
+sudo firewall-cmd --permanent --zone work --add-port 5001/tcp || exit 1
 sudo firewall-cmd --reload || exit 1
 
 exec sudo ./Code/bin/dlv exec /usr/local/bin/node-agent --api-version 2 --headless --listen 0.0.0.0:5001 -- --ignore-ports 5001 "$@"

--- a/scripts/debug-remote-na.sh
+++ b/scripts/debug-remote-na.sh
@@ -7,10 +7,13 @@ DEST="orbiter@$2"
 shift
 shift
 
-scp -i $KEY ./scripts/stop-na.sh $DEST:/usr/local/bin/stop-na.sh
-ssh -i $KEY $DEST stop-na.sh
+scp -i $KEY ./scripts/stop-na.sh $DEST:/home/orbiter/stop-na-tmp.sh
+ssh -i $KEY $DEST -- sudo mv /home/orbiter/stop-na-tmp.sh /usr/local/bin/stop-na.sh
+ssh -i $KEY $DEST -- stop-na.sh
 go run ./cmd/chore/dev/executables/*.go
-scp -i $KEY ./artifacts/nodeagent $DEST:/usr/local/bin/node-agent
-scp -i $KEY ./scripts/debug-na.sh $DEST:/usr/local/bin/debug-na.sh
-ssh -i $KEY $DEST debug-na.sh "$@"
+scp -i $KEY ./artifacts/nodeagent $DEST:/home/orbiter/node-agent-tmp
+ssh -i $KEY $DEST -- sudo mv /home/orbiter/node-agent-tmp /usr/local/bin/node-agent
+scp -i $KEY ./scripts/debug-na.sh $DEST:/home/orbiter/debug-na-tmp.sh
+scp -i $KEY $DEST -- sudo mv /home/orbiter/debug-na-tmp.sh /usr/local/bin/debug-na.sh
+ssh -i $KEY $DEST debug-na.sh $(curl ifconfig.co/) "$@"
 

--- a/scripts/develop-na.sh
+++ b/scripts/develop-na.sh
@@ -5,8 +5,15 @@ set -ex
 KEY=$1
 DEST="orbiter@$2"
 
+shift
+shift
+
 ./scripts/build-debug-bins.sh --host-bins-only --commit debug 
-scp -i $KEY ./scripts/stop-na.sh $DEST:/usr/local/bin/stop-na.sh
+scp -i $KEY ./scripts/stop-na.sh $DEST:/home/orbiter/stop-na-tmp.sh
+ssh -i $KEY $DEST -- sudo mv /home/orbiter/stop-na-tmp.sh /usr/local/bin/stop-na.sh
 ssh -i $KEY $DEST -- stop-na.sh
-scp -i $KEY ./artifacts/nodeagent $DEST:/usr/local/bin/node-agent
-./scripts/debug-remote-na.sh "$@"
+scp -i $KEY ./artifacts/nodeagent $DEST:/home/orbiter/node-agent-tmp
+ssh -i $KEY $DEST -- sudo mv /home/orbiter/node-agent-tmp /usr/local/bin/node-agent
+scp -i $KEY ./scripts/debug-na.sh $DEST:/home/orbiter/debug-na-tmp.sh
+ssh -i $KEY $DEST -- sudo mv /home/orbiter/debug-na-tmp.sh /usr/local/bin/debug-na.sh
+ssh -i $KEY $DEST debug-na.sh $(curl ifconfig.co/) "$@"

--- a/scripts/stop-na.sh
+++ b/scripts/stop-na.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-set -ex
+set -x
 
-sudo systemctl stop node-agentd || exit 1
+sudo systemctl stop node-agentd
+CODE="$?"
+if [[ "$CODE" == "5" ]]; then
+    exit 0
+elif [[ "$CODE" != "0" ]]; then
+    exit 1
+fi
 sudo kill $(pgrep dlv) 2> /dev/null || true


### PR DESCRIPTION
When kubeadm with a specific version is ensured, yum also installs
kubeadms dependencies kubectl and kubelet, but at the latest version.
Whatever the reason for that is...

✅ Closes: #826