### PR TITLE
fix: disable gpg checks for https yum repos

### DIFF
--- a/internal/operator/nodeagent/dep/k8s/common.go
+++ b/internal/operator/nodeagent/dep/k8s/common.go
@@ -55,7 +55,7 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg`), 0644); err != nil {
 				return err
 			}

--- a/internal/operator/nodeagent/dep/package-manager-init.go
+++ b/internal/operator/nodeagent/dep/package-manager-init.go
@@ -56,6 +56,10 @@ func (p *PackageManager) remSpecificDisableGPGRepoCheckForGcloudRepo() error {
 
 func (p *PackageManager) remSpecificUpdatePackages() error {
 
+	if err := p.remSpecificDisableGPGRepoCheckForGcloudRepo(); err != nil {
+		return err
+	}
+
 	conflictingCronFile := "/etc/cron.daily/yumupdate.sh"
 	removeConflictingCronFile := true
 	_, err := os.Stat(conflictingCronFile)

--- a/internal/operator/nodeagent/dep/package-manager-init.go
+++ b/internal/operator/nodeagent/dep/package-manager-init.go
@@ -32,6 +32,10 @@ func (p *PackageManager) debSpecificInit() error {
 
 func (p *PackageManager) remSpecificInit() error {
 
+	if err := p.remSpecificDisableGPGRepoCheckForGcloudRepo(); err != nil {
+		return err
+	}
+
 	return p.rembasedInstall(
 		&Software{Package: "yum-utils"},
 		&Software{Package: "yum-plugin-versionlock"},
@@ -51,10 +55,6 @@ func (p *PackageManager) remSpecificDisableGPGRepoCheckForGcloudRepo() error {
 }
 
 func (p *PackageManager) remSpecificUpdatePackages() error {
-
-	if err := p.remSpecificDisableGPGRepoCheckForGcloudRepo(); err != nil {
-		return err
-	}
 
 	conflictingCronFile := "/etc/cron.daily/yumupdate.sh"
 	removeConflictingCronFile := true


### PR DESCRIPTION
As I read [googles explanation](https://cloud.google.com/compute/docs/troubleshooting/known-issues#known_issues_for_linux_vm_instances), it is safe to disable Yum GPG checks for HTTPS repos. 